### PR TITLE
2-add-a-simpler-way-to-go-to-a-specific-page-after-paginated-a-model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Calling `Model::paginate()` will no longer raise an error.
 
+### Added
+
+- New Folded exclusive method `Model::toPage(2)` to go to a specific page before calling `->paginate(15)`.
+
 ## [0.1.1] 2020-09-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ As this library relies on Eloquent, you will find a useful amount of information
 - [1. Get all the data from your model](#1-get-all-the-data-from-your-model)
 - [2. Add more information to the database connection](#2-add-more-information-to-the-database-connection)
 - [3. Enable/disable eloquent events](#3-enable-disable-eloquent-events)
+- [4. Go to a specific page before paginating](#4-go-to-a-specific-page-before-paginating)
 
 ### 1. Get all the data from your model
 
@@ -136,6 +137,28 @@ use function Folded\disableEloquentEvents;
 
 enableEloquentEvents();
 disableEloquentEvents();
+```
+
+### 4. Go to a specific page before paginating
+
+In this example, we will instruct the paginator to go to a certain page before paginating. As we are not in Laravel, this is required to correctly returns the items according to the browsed page.
+
+```php
+$posts = Post::toPage(2)->paginate(15);
+```
+
+The page number should come for example from the query strings, like when the user browse `/post?page=2`.
+
+However, for technical reasons, I could not find how to provide the same method after you call eloquent methods before. Which means that the following code will not work:
+
+```php
+$posts = Post::where("author", "foo")->toPage(2)->paginate(15);
+```
+
+To fix this issue, use the verbose version of `->paginate()`:
+
+```php
+$posts = Post::where("author", "foo")->paginate(15, ["*"], "page", 2); // 2 is the page number
 ```
 
 ## Version support

--- a/src/Model.php
+++ b/src/Model.php
@@ -4,10 +4,13 @@ declare(strict_types = 1);
 
 namespace Folded;
 
+use OutOfRangeException;
 use Illuminate\Database\Capsule\Manager;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Represents a class that reflects a table in the database.
@@ -107,6 +110,33 @@ class Model extends EloquentModel
     public static function enableEvents(): void
     {
         self::$eventsEnabled = true;
+    }
+
+    /**
+     * Instruct the paginate method to go to the desired page.
+     *
+     * Shortcut over the verbose ->paginate(15, ["*"], "page", $pageNumber = 2);
+     *
+     * @param int $pageNumber The page you want to go.
+     *
+     * @throws OutOfRangeException If the page number is below 1.
+     *
+     * @since 0.2.0
+     *
+     * @example
+     * Model::toPage(2)->paginate(15);
+     */
+    public static function toPage(int $pageNumber): Builder
+    {
+        if ($pageNumber < 1) {
+            throw new OutOfRangeException("page number must be greater or equal to 1");
+        }
+
+        AbstractPaginator::currentPageResolver(function () use ($pageNumber) {
+            return $pageNumber;
+        });
+
+        return self::query();
     }
 
     /**

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -54,3 +54,28 @@ it("should paginate the model", function (): void {
         'total' => 0,
     ]);
 });
+
+it("should go to the desired page", function (): void {
+    DatabaseConnections::add([
+        "driver" => "sqlite",
+        "database" => __DIR__ . "/misc/database.sqlite",
+    ]);
+
+    $secondPost = [
+        "id" => 2,
+        "excerpt" => "Bar post.",
+        "title" => "Bar",
+    ];
+
+    Post::insert(
+        [
+            "id" => 1,
+            "title" => "Foo",
+            "excerpt" => "Foo post.",
+        ]
+    );
+
+    Post::insert($secondPost);
+
+    expect(Post::toPage(2)->paginate(1)->items()[0]->toArray())->toBe($secondPost);
+});


### PR DESCRIPTION
## Added 

- New method `Model::toPage(2)->paginate(15)` to have a shortcut over the verbose version of `->paginate(15, ["*"], "page", 2)`

## Fixed

None.

## Breaking

None.