### PR TITLE
8-missing-namespace-in-function-exists-call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added missing namespace `Folded` to `function_exists` statements.
+
 ## [0.2.0] 2020-09-12
 
 ### Fixed

--- a/src/addDatabaseConnection.php
+++ b/src/addDatabaseConnection.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("addDatabaseConnection")) {
+if (!function_exists("Folded\addDatabaseConnection")) {
     /**
      * Add a new database connection.
      *

--- a/src/disableEloquentEvents.php
+++ b/src/disableEloquentEvents.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("disableEloquentEvents")) {
+if (!function_exists("Folded\disableEloquentEvents")) {
     /**
      * Disables the Eloquent event system for all the models.
      *

--- a/src/enableEloquentEvents.php
+++ b/src/enableEloquentEvents.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("enableEloquentEvents")) {
+if (!function_exists("Folded\enableEloquentEvents")) {
     /**
      * Enables the Eloquent event system for all the models.
      *


### PR DESCRIPTION
## Added

 None.

## Fixed

- Bug when namespace `Folded` was missing from `function_exists` statements.

## Breaking

None.